### PR TITLE
feat: Initial version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # testing
-Shared testing framework for Source projects
+Shared testing framework for Source projects.
+
+This repository provides a shared language for writing tests across Source Network projects.  Tests are composed entirely of [action.Action]s, [multiplier.Multiplier]s may be configured to mutate the declared actions to scale with various project-specific complexity multipliers.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ func (test *Test) Execute(t testing.TB) {
 
 	multiplier.Skip(t, test.Includes, test.Excludes)
 
-	actions := prependStart(test.Actions)
-
 	actions = multiplier.Apply(actions)
 
 	testing.Log(t, actions)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,99 @@
 # testing
 Shared testing framework for Source projects.
 
-This repository provides a shared language for writing tests across Source Network projects.  Tests are composed entirely of [action.Action]s, [multiplier.Multiplier]s may be configured to mutate the declared actions to scale with various project-specific complexity multipliers.
+This repository provides a shared language for writing tests across Source Network projects.  Tests are composed entirely of `action.Action`s, `multiplier.Multiplier`s may be configured to mutate the declared actions to scale with various project-specific complexity multipliers.
+
+### Example consumption
+
+The following example taken from the Defra CLI package, and shows a simple test `TestSchemaAdd` along with the shared test executor for the test-package.
+```
+// testing.go
+
+package integration
+
+func init() {
+	multiplier.Init("DEFRA_MULTIPLIERS", "txn-commit")
+}
+
+type Test struct {
+	// The test will be skipped if the current active set of multipliers
+	// does not contain all of the given multiplier names.
+	Includes []multiplier.Name
+
+	// The test will be skipped if the current active set of multipliers
+	// contains any of the given multiplier names.
+	Excludes []multiplier.Name
+
+	// Actions contains the set of actions that should be
+	// executed as part of this test.
+	Actions action.Actions
+}
+
+func (test *Test) Execute(t testing.TB) {
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 1*time.Second)
+
+	multiplier.Skip(t, test.Includes, test.Excludes)
+
+	actions := prependStart(test.Actions)
+
+	actions = multiplier.Apply(actions)
+
+	testing.Log(t, actions)
+
+	testing.ExecuteS(actions, &state.State{
+		T:       t,
+		Ctx:     ctx,
+		Cancels: []context.CancelFunc{cancel},
+	})
+}
+```
+```
+// multiplier/txn.go
+
+func init() {
+	multiplier.Register(&txnCommit{})
+}
+
+const TxnCommit Name = "txn-commit"
+
+type txnCommit struct{}
+
+var _ Multiplier = (*txnCommit)(nil)
+
+func (n *txnCommit) Name() Name {
+	return TxnCommit
+}
+
+func (n *txnCommit) Apply(source action.Actions) action.Actions {
+   ...
+}
+```
+```
+// simple_test.go
+
+func TestSchemaAdd(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.SchemaAdd{
+				InlineSchema: `
+					type User {}
+				`,
+			},
+			&action.CollectionDescribe{
+				Expected: []client.CollectionDefinition{
+					{
+						Description: client.CollectionDescription{
+							Name:           immutable.Some("User"),
+							IsMaterialized: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provides a shared language for writing tests across Source Netwo
 
 ### Example consumption
 
-The following example taken from the Defra CLI package, and shows a simple test `TestSchemaAdd` along with the shared test executor for the test-package.
+The following example was taken from the Defra CLI package, and shows a simple test `TestSchemaAdd` along with the shared test executor for the test-package.
 ```
 // testing.go
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # testing
 Shared testing framework for Source projects.
 
-This repository provides a shared language for writing tests across Source Network projects.  Tests are composed entirely of `action.Action`s, `multiplier.Multiplier`s may be configured to mutate the declared actions to scale with various project-specific complexity multipliers.
+This repository provides a shared language for writing tests across Source Network projects.  Tests are composed entirely of `action.Action`s. `multiplier.Multiplier`s may be configured to mutate the declared actions to scale with various project-specific complexity multipliers.
 
 ### Example consumption
 

--- a/action/action.go
+++ b/action/action.go
@@ -1,0 +1,12 @@
+package action
+
+// Action represents an item to be executed as part of a test.
+//
+// For example an action may set or get a value, or it may close the datastore.
+type Action interface {
+	// Execute this action upon the given state.
+	Execute()
+}
+
+// Actions is an executable set of [Action]s.
+type Actions []Action

--- a/action/action.go
+++ b/action/action.go
@@ -9,4 +9,4 @@ type Action interface {
 }
 
 // Actions is an executable set of [Action]s.
-type Actions []Action
+type Actions = []Action

--- a/action/stateful.go
+++ b/action/stateful.go
@@ -4,6 +4,10 @@ package action
 //
 // It is commonly used by [Action]s, and the state will be
 // set by various functions within the source testing packages.
+//
+// For example, [github.com/sourcenetwork/testing.ExecuteS] calls
+// [Stateful.SetState] for every action provided to it, allowing those
+// given actions to access the test state during test execution.
 type Stateful[TState any] interface {
 	// SetState overwrites currently held state with the given value.
 	SetState(TState)

--- a/action/stateful.go
+++ b/action/stateful.go
@@ -1,0 +1,10 @@
+package action
+
+// Stateful represents an object who's state may be set.
+//
+// It is commonly used by [Action]s, and the state will be
+// set by various functions within the source testing packages.
+type Stateful[TState any] interface {
+	// SetState overwrites currently held state with the given value.
+	SetState(TState)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sourcenetwork/testing
 
-go 1.20
+go 1.23

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sourcenetwork/testing
+
+go 1.20

--- a/multiplier/multiplier.go
+++ b/multiplier/multiplier.go
@@ -1,0 +1,138 @@
+package multiplier
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sourcenetwork/testing/action"
+)
+
+var activeMultipliers []Multiplier
+var availableMultipliers []Multiplier
+
+// Name represents the unique name of a multiplier.
+//
+// The alias provides a more descriptive type to use besides `string`.
+type Name = string
+
+// Multiplier represents a complexity multiplier of the system under test.
+//
+// It represents a concept that multiplies the surface area and complexity
+// of other proximal features, for example, database transactions are
+// complexity modifiers, as when adding many new database actions such as
+// a new filter operation, the new action must be tested both with, and without
+// a transaction - the transaction concept multiplies the complexity of the system.
+//
+// The identification and automatic representation of complexity multipiers are critical
+// to the long term maintainability and scalability of a codebase. Without them, introducing
+// fairly simple features becomes high risk, and requires a forever growing number of manually
+// constructed tests, when the feature developer needs to remember, and write tests for every
+// multiplier that affects the feature under test.  This is error prone, very tedious, and
+// distracts from the feature itself - often degrading the quality of both test and production code.
+//
+// Complexity multipliers defined using this type may redefine the set of test actions
+// to perform within a test, allowing a single test to scale with the complexity
+// multiplier.  For example, applying a 'namespace' multplier may add an action that
+// namespaces the store under test, reducing, but not removing, testing cost of the
+// namespace multiplier.
+type Multiplier interface {
+	// Name returns the unique name of the multiplier.
+	Name() Name
+
+	// Apply applies the complexity multiplier to the given action set, returning a new
+	// action set testing the multiplier.
+	Apply(source action.Actions) action.Actions
+}
+
+// Register adds the given multiplier to the internal set of available multipliers.
+//
+// Multipliers must be registered before calling [Init] in order to be applied.
+func Register(multiplier Multiplier) {
+	availableMultipliers = append(availableMultipliers, multiplier)
+}
+
+// Init initializes the multiplier engine, determining which multipliers are to
+// be applied to action sets.
+//
+// It must be called after all required [Multiplier]s are [Register]ed.
+//
+// It will check to see if the given environment variable is set, and if so,
+// sources the comma sperated set of multiplier names from it.  If the
+// environment variable is not set, it will use the provided defaults.
+//
+// Multipliers will be applied in the order in which they are given.
+func Init(envVarName string, defaults ...Name) {
+	var multiplierNames []string
+	multipliersString, ok := os.LookupEnv(envVarName)
+	if ok {
+		multiplierNames = strings.Split(multipliersString, ",")
+	} else {
+		multiplierNames = defaults
+	}
+
+	for i, name := range multiplierNames {
+		multiplierNames[i] = strings.TrimSpace(name)
+	}
+
+	availableMultipliersByName := make(map[Name]Multiplier, len(availableMultipliers))
+	for _, multiplier := range availableMultipliers {
+		availableMultipliersByName[multiplier.Name()] = multiplier
+	}
+
+	activeMultipliers = make([]Multiplier, 0, len(multiplierNames))
+	for _, multiplierName := range multiplierNames {
+		if multiplier, ok := availableMultipliersByName[multiplierName]; ok {
+			activeMultipliers = append(activeMultipliers, multiplier)
+		}
+	}
+}
+
+// Apply applies all active multipliers to the given action set, in the order in which the
+// multipliers are provided.
+func Apply(actions action.Actions) action.Actions {
+	for _, multiplier := range activeMultipliers {
+		actions = multiplier.Apply(actions)
+	}
+
+	return actions
+}
+
+// Skip skips the test if:
+//   - The active set of multipliers does not contain a multiplier with a name exactly matching
+//     a value in the given `includes` set.
+//   - The active set of multipliers contains a multiplier with a name exactly matching
+//     a value in the given `excludes` set.
+func Skip(t testing.TB, includes []Name, excludes []Name) {
+	for _, multiplier := range activeMultipliers {
+		for _, exclude := range excludes {
+			if multiplier.Name() == exclude {
+				t.Skipf("skipping, multiplier is excluded. Name: %s", exclude)
+			}
+		}
+	}
+
+	for _, include := range includes {
+		included := false
+		for _, multiplier := range activeMultipliers {
+			if multiplier.Name() == include {
+				included = true
+				break
+			}
+		}
+
+		if !included {
+			t.Skipf("skipping, required multiplier is not included. Name: %s", include)
+		}
+	}
+}
+
+// Get returns a comma-seperated string containing the current active multiplier names.
+func Get() string {
+	multipliers := make([]string, len(activeMultipliers))
+	for i, multiplier := range activeMultipliers {
+		multipliers[i] = multiplier.Name()
+	}
+
+	return strings.Join(multipliers, ",")
+}

--- a/multiplier/multiplier.go
+++ b/multiplier/multiplier.go
@@ -1,3 +1,28 @@
+/*
+The multiplier package provides a collection of functions used to help scale tests with
+the complexity multipliers present in the production code.
+
+A complexity multiplier represents a concept that multiplies the surface area and complexity
+of other proximal features, for example, database transactions are complexity modifiers, as
+when adding many new database actions such as a new filter operation, the new action must be
+tested both with, and without a transaction - the transaction concept multiplies the complexity
+of the system.
+
+Complexity multipliers are represented in this package by the [Multiplier] interface.  Concrete
+implementations of this interface should be defined in the packages consuming this package, and then
+registered by calling [Register].  This is typically done in an `init` function in the package defining
+the concrete type.
+
+Once all desired [Multiplier]s have been registered, [Init] should be called in order to select
+which of the registered multipliers are active and should be used to modify the set of actions provided
+to [Apply].
+
+[Apply] should be called once per test, and will modify the given set of actions in order to test the
+active complexity multipliers.
+
+[Multiplier]s do not have any impact during action execution, they act only on the action set itself,
+redefining, creating or deleting elements from the test definition *before* the action set executes.
+*/
 package multiplier
 
 import (

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,73 @@
+package stest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	stdT "testing"
+
+	"github.com/sourcenetwork/testing/action"
+	"github.com/sourcenetwork/testing/multiplier"
+)
+
+// Execute this set of actions, serially, in order.
+func Execute(a action.Actions) {
+	for _, action := range a {
+		action.Execute()
+	}
+}
+
+// Execute this set of actions upon the given state, serially, in order.
+func ExecuteS[TState any](actions action.Actions, s TState) {
+	for _, a := range actions {
+		if stateful, ok := a.(action.Stateful[TState]); ok {
+			stateful.SetState(s)
+		}
+
+		a.Execute()
+	}
+}
+
+// Log the set of active multipliers and the provided actions.
+//
+// The first line will be empty.
+// Multipliers will be logged on the second line, as comma separated values.
+// Actions will be logged on the third line as prettified json, including the
+// action concrete type in a `_type` property.
+//
+// For example:
+//
+//	 Multipliers: txn-commit
+//	 Actions: [
+//	  {
+//		"_type": "*action.StartCli"
+//	  },
+//	  {
+//		"_type": "*action.TxCreate"
+//	  },
+//	  {
+//		"_type": "*action.TxCommit",
+//		"TxnIndex": 0
+//	  }
+//	]
+func Log(t stdT.TB, actions action.Actions) {
+	typedActions := make([]json.RawMessage, 0, len(actions))
+	for _, a := range actions {
+		actionJson, _ := json.MarshalIndent(a, "", "  ")
+
+		var deliminator string
+		if !bytes.Equal(actionJson, []byte("{}")) {
+			deliminator = ","
+		}
+
+		jsonString := fmt.Sprintf("{\n  \"_type\":\"%T\"%s%s", a, deliminator, actionJson[1:])
+		typedActions = append(typedActions, json.RawMessage(jsonString))
+	}
+
+	jsonB, err := json.MarshalIndent(typedActions, "", "  ")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	t.Logf("\nMultipliers: %s\nActions: %s", multiplier.Get(), string(jsonB))
+}


### PR DESCRIPTION
## Description

Largely as seen in the demo in the standup, just polished up a little bit.

I am thinking of exporting this as `stest`, as at the moment in order to consume the root package you must either alias the std lib `"testing"` or this package as they are pretty much always going to be imported together and the names currently clash.  E.g.:
```
import (
	"testing"

	stest "github.com/sourcenetwork/testing"
)
```
Could become:
```
import (
	"testing"

	"github.com/sourcenetwork/stest"
)
```
Which would be much easier via intelisense, and a little less tedious to do.  I can either do this by recreating this repo under that path, or by exporting the module with a name different to the repo path.  Please let me know your thoughts on this.

### Example consumption (Defra/cli)
```
// testing.go

func (test *Test) Execute(t testing.TB) {
	ctx := context.Background()
	var cancel context.CancelFunc
	ctx, cancel = context.WithTimeout(ctx, 1*time.Second)

	multiplier.Skip(t, test.Includes, test.Excludes)

	actions := prependStart(test.Actions)

	actions = multiplier.Apply(actions)

	stest.Log(t, actions)

	stest.ExecuteS(actions, &state.State{
		T:       t,
		Ctx:     ctx,
		Cancels: []context.CancelFunc{cancel},
	})
}
```
```
// simple_test.go
func TestSchemaAdd(t *testing.T) {
	test := &integration.Test{
		Actions: []action.Action{
			&action.SchemaAdd{
				InlineSchema: `
					type User {}
				`,
			},
			&action.CollectionDescribe{
				Expected: []client.CollectionDefinition{
					{
						Description: client.CollectionDescription{
							Name:           immutable.Some("User"),
							IsMaterialized: true,
						},
					},
				},
			},
		},
	}

	test.Execute(t)
}
```
Additional examples can be found in https://github.com/sourcenetwork/defradb/pull/3550

## Todo
- [x] Fred ~~and Shahzad~~ (Shahzad is unavailable this week, this will be merged without his review) want to review this, wait for them